### PR TITLE
Update CrossClusterDataSteps.md

### DIFF
--- a/CrossClusterDataSteps.md
+++ b/CrossClusterDataSteps.md
@@ -99,7 +99,7 @@ oc process -f ./cross-cluster/target-migrator-tmpl.yaml \
 
 4. Get token for remote secret value and create secret manifest for source (shortcut below)
 ``` bash
-MIG_TOKEN_SECRET=`oc get secret | jq '.items[] | select(.type == "kubernetes.io/service-account-token") | .metadata.name' | grep target-pvc-migrator-token | head -1 | awk '{print $1}'`
+MIG_TOKEN_SECRET=`oc get secret -o json | jq '.items[] | select(.type == "kubernetes.io/service-account-token") | .metadata.name' | grep target-pvc-migrator-token | head -1 | awk '{print $1}'`
 # Use token value to generate local temp secret
 oc create secret generic x-cluster-test --from-literal=token=`oc get secret ${MIG_TOKEN_SECRET} -o json | jq -r .data.token | base64 -d` --dry-run=client -o json > tmp.secret
 ```

--- a/CrossClusterDataSteps.md
+++ b/CrossClusterDataSteps.md
@@ -99,7 +99,7 @@ oc process -f ./cross-cluster/target-migrator-tmpl.yaml \
 
 4. Get token for remote secret value and create secret manifest for source (shortcut below)
 ``` bash
-MIG_TOKEN_SECRET=`oc get secret | grep target-pvc-migrator-token | head -1 | awk '{print $1}'`
+MIG_TOKEN_SECRET=`oc get secret | jq '.items[] | select(.type == "kubernetes.io/service-account-token") | .metadata.name' | grep target-pvc-migrator-token | head -1 | awk '{print $1}'`
 # Use token value to generate local temp secret
 oc create secret generic x-cluster-test --from-literal=token=`oc get secret ${MIG_TOKEN_SECRET} -o json | jq -r .data.token | base64 -d` --dry-run=client -o json > tmp.secret
 ```


### PR DESCRIPTION
I found that there are situations where the order of secrets you'd get by the instruction `oc get secret -n {{ migrator_vars.cluster_b.namespace }} ` could lead to the `dockercfg` secret being selected by the piped `head` command. 

Adding a jq filter prior to ensure only service account tokens are selected.