### PR TITLE
Fix missing double quote in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/openshift/origin-cli:latest
 
-LABEL maintainer="Jeff Kelly <jeff.kelly@arctiq.ca>
+LABEL maintainer="Jeff Kelly <jeff.kelly@arctiq.ca>"
 LABEL io.k8s.description="Storage Migration Placeholder"
 
 WORKDIR /

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ LABEL io.k8s.description="Storage Migration Placeholder"
 
 WORKDIR /
 
-RUN yum update
+RUN yum update -y
 RUN yum -y install rsync curl && yum clean all -y
 
 RUN mkdir /source /target

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ LABEL io.k8s.description="Storage Migration Placeholder"
 WORKDIR /
 
 RUN yum update -y
-RUN yum -y install rsync curl && yum clean all -y
+RUN yum -y install rsync curl --allowerasing && yum clean all -y
 
 RUN mkdir /source /target
 COPY migrate /

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,7 @@ LABEL io.k8s.description="Storage Migration Placeholder"
 
 WORKDIR /
 
+RUN yum update
 RUN yum -y install rsync curl && yum clean all -y
 
 RUN mkdir /source /target


### PR DESCRIPTION
Build fails with the following error:
`error: build error: resolving step {Value:label Next:0xc0003f8a80 Children:[] Attributes:map[] Original:LABEL maintainer="Jeff Kelly <jeff.kelly@arctiq.ca> Flags:[] StartLine:2 EndLine:2}: unexpected end of statement while looking for matching double-quote`

Replacing missing double quote to fix this